### PR TITLE
Implement command resending and missing EDU commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,29 +20,47 @@ $ pip install requirements.txt
 
 ### Simple example
 
-```
+```python
 from djitellopy import Tello
 import cv2
 import time
 
-
 tello = Tello()
 
 tello.connect()
-
 tello.takeoff()
-time.sleep(5)
 
 tello.move_left(100)
-time.sleep(5)
-
 tello.rotate_counter_clockwise(45)
-time.sleep(5)
 
 tello.land()
-time.sleep(5)
-        
 tello.end()
+```
+
+### Swarm example
+```python
+from djitellopy import TelloSwarm
+
+swarm = TelloSwarm.fromIps([
+    "192.168.178.42",
+    "192.168.178.43",
+    "192.168.178.44"
+])
+
+swarm.connect()
+swarm.takeoff()
+
+# run in parallel on all tellos
+swarm.move_up(100)
+
+# run by one tello after the other
+swarm.sequential(lambda i, tello: tello.move_forward(i * 20))
+
+# making each tello do something unique in parallel
+swarm.parallel(lambda i, tello: tello.move_left(i * 100))
+
+swarm.land()
+swarm.end()
 ```
 
 ### Example using pygame and the video stream
@@ -55,8 +73,11 @@ The controls are:
 - A and D: Counter clockwise and clockwise rotations
 - W and S: Up and down.
 
-### Note
-If you are using the ```streamon``` command and the response is ```Unknown command``` means you have to update the Tello firmware. That can be done through the Tello app.
+### Notes
+- If you are using the ```streamon``` command and the response is ```Unknown command``` means you have to update the Tello firmware. That can be done through the Tello app.
+- Mission pad detection and navigation is only supported by the Tello EDU
+- Connecting to an existing wifi network is only supported by the Tello EDU
+- When connected to an existing wifi network video streaming is not available
 
 ## Author
 

--- a/djitellopy/__init__.py
+++ b/djitellopy/__init__.py
@@ -1,1 +1,2 @@
 from djitellopy.tello import Tello, BackgroundFrameRead
+from djitellopy.swarm import TelloSwarm

--- a/djitellopy/swarm.py
+++ b/djitellopy/swarm.py
@@ -7,8 +7,11 @@ class TelloSwarm:
 		with open(path, "r") as fd:
 			ips = fd.readlines()
 
+		return TelloSwarm.fromIps(ips, enable_exceptions)
+
+	def fromIps(ips, enable_exceptions=True):
 		if len(ips) == 0:
-			raise "Empty file"
+			raise Exception("No ips provided")
 
 		firstTello = Tello(ips[0])
 		tellos = [firstTello]

--- a/djitellopy/swarm.py
+++ b/djitellopy/swarm.py
@@ -1,0 +1,71 @@
+from djitellopy import Tello
+from threading import Thread, Barrier
+from queue import Queue
+
+class TelloSwarm:
+	def fromFile(path, enable_exceptions=True):
+		with open(path, "r") as fd:
+			ips = fd.readlines()
+
+		if len(ips) == 0:
+			raise "Empty file"
+
+		firstTello = Tello(ips[0])
+		tellos = [firstTello]
+
+		for ip in ips[1:]:
+			tellos.append(Tello(
+				ip,
+				client_socket=firstTello.clientSocket,
+				enable_exceptions=enable_exceptions
+			))
+
+		return TelloSwarm(tellos)
+
+	def __init__(self, tellos):
+		self.tellos = tellos
+		self.barrier = Barrier(len(tellos))
+		self.funcBarrier = Barrier(len(tellos) + 1)
+		self.funcQueues = [Queue() for tello in tellos]
+
+		def worker(i):
+			queue = self.funcQueues[i]
+			tello = self.tellos[i]
+
+			while True:
+				func = queue.get()
+				self.funcBarrier.wait()
+				func(i, tello)
+				self.funcBarrier.wait()
+
+		self.threads = []
+		for i, tello in enumerate(tellos):
+			thread = Thread(target=worker, daemon=True, args=(i,))
+			thread.start()
+			self.threads.append(thread)
+
+	def sequential(self, func):
+		for i, tello in enumerate(self.tellos):
+			func(i, tello)
+
+	def parallel(self, func):
+		for queue in self.funcQueues:
+			queue.put(func)
+		
+		self.funcBarrier.wait()
+		self.funcBarrier.wait()
+
+	def sync(self, timeout=None):
+		return self.barrier.wait(timeout)
+
+	def __getattr__(self, attr):
+		def callAll(*args, **kwargs):
+			self.parallel(lambda i, tello: getattr(tello, attr)(*args, **kwargs))
+
+		return callAll
+
+	def __iter__(self):
+		return iter(self.tellos)
+
+	def __len__(self):
+		return len(self.tellos)

--- a/djitellopy/tello.py
+++ b/djitellopy/tello.py
@@ -35,7 +35,7 @@ class Tello:
         host='192.168.10.1',
         port=8889,
         client_socket=None,
-        enable_exceptions=False,
+        enable_exceptions=True,
         retry_count=3):
 
         self.address = (host, port)
@@ -464,6 +464,63 @@ class Tello:
             bool: True for successful, False for unsuccessful
         """
         return self.send_command_without_return('curve %s %s %s %s %s %s %s' % (x1, y1, z1, x2, y2, z2, speed))
+
+    @accepts(x=int, y=int, z=int, speed=int, mid=int)
+    def go_xyz_speed_mid(self, x, y, z, speed, mid):
+        """Tello fly to x y z in speed (cm/s) relative to mission pad iwth id mid
+        Arguments:
+            x: -500-500
+            y: -500-500
+            z: -500-500
+            speed: 10-100
+            mid: 1-8
+        Returns:
+            bool: True for successful, False for unsuccessful
+        """
+        return self.send_control_command('go %s %s %s %s m%s' % (x, y, z, speed, mid))
+
+    @accepts(x1=int, y1=int, z1=int, x2=int, y2=int, z2=int, speed=int, mid=int)
+    def curve_xyz_speed_mid(self, x1, y1, z1, x2, y2, z2, speed, mid):
+        """Tello fly to x2 y2 z2 over x1 y1 z1 in speed (cm/s) relative to mission pad with id mid
+        Arguments:
+            x1: -500-500
+            y1: -500-500
+            z1: -500-500
+            x2: -500-500
+            y2: -500-500
+            z2: -500-500
+            speed: 10-60
+            mid: 1-8
+        Returns:
+            bool: True for successful, False for unsuccessful
+        """
+        return self.send_control_command('curve %s %s %s %s %s %s %s m%s' % (x1, y1, z1, x2, y2, z2, speed, mid))
+
+    @accepts(x=int, y=int, z=int, speed=int, yaw=int, mid1=int, mid2=int)
+    def go_xyz_speed_yaw_mid(self, x, y, z, speed, yaw, mid1, mid2):
+        """Tello fly to x y z in speed (cm/s) relative to mid1
+        Then fly to 0 0 z over mid2 and rotate to yaw relative to mid2's rotation
+        Arguments:
+            x: -500-500
+            y: -500-500
+            z: -500-500
+            speed: 10-100
+            yaw: -360-360
+            mid1: 1-8
+            mid2: 1-8
+        Returns:
+            bool: True for successful, False for unsuccessful
+        """
+        return self.send_control_command('jump %s %s %s %s %s m%s m%s' % (x, y, z, speed, yaw, mid1, mid2))
+
+    def enable_mission_pads(self):
+        return self.send_control_command("mon")
+
+    def disable_mission_pads(self):
+        return self.send_control_command("moff")
+
+    def set_mission_pad_detection_direction(self, x):
+        return self.send_control_command("mdirection " + str(x))
 
     @accepts(x=int)
     def set_speed(self, x):


### PR DESCRIPTION
Hey,

we recently bought 4 Tello EDUs. We successfully flew them in a swarm using this library and made some improvements:
- often commands fail because they take too long -> increased timeout
- when a command packet is dropped or not received it simply proceeds with the next one, this is especially bad with 4 drones when 3 receive the command and one doesn't -> retry the commands
- when a command fails after all tries it raises an exception instead of just returning
- implements the missing commands relating to the mission pads (see the [SDK 2.0 user guide](https://dl-cdn.ryzerobotics.com/downloads/Tello/Tello%20SDK%202.0%20User%20Guide.pdf))
- implement missing get sdk version number and serial number commands 
- allow to supply retrieve socket via an argument, so multiple Tello instances can share one receive socket

TODOs:
- [x] TelloSwarm class
- [ ] Tello State protocol (retrieved on port 8990)
- [ ] Filter incoming packages by the ip of the remote tello