### PR TITLE
rewrite state parsing and enhance networking code

### DIFF
--- a/djitellopy/swarm.py
+++ b/djitellopy/swarm.py
@@ -13,13 +13,10 @@ class TelloSwarm:
 		if len(ips) == 0:
 			raise Exception("No ips provided")
 
-		firstTello = Tello(ips[0])
-		tellos = [firstTello]
-
-		for ip in ips[1:]:
+		tellos = []
+		for ip in ips:
 			tellos.append(Tello(
-				ip,
-				client_socket=firstTello.clientSocket,
+				host=ip.strip(),
 				enable_exceptions=enable_exceptions
 			))
 


### PR DESCRIPTION
Hey,

The implementation of the state protocol worked, but it split the state string and used offsets every time one requested a single state field. Instead by parsing the state protocol once and storing it in a dict is not only more performant but also more future proof in case of further field additions to the protocol (see 268dbbf).

Before this commit every drone would try to create a state socket, basically breaking multi-drone setups (swarms), as the same port cannot be listened on twice. Also the response receiver did not check which drone a response actually came from. Commits 552edd1 and 143fe76 make sure responses are forwarded to the correct Tello instances.