### PR TITLE
Compatability & Example fix

### DIFF
--- a/djitellopy/decorators.py
+++ b/djitellopy/decorators.py
@@ -52,6 +52,6 @@ def get_state_decorator(func):
             try:
                 return func(instance, *args, **kwargs)
             except:
-                instance.LOGGER.error(f"Exception in {func.__name__} occured")
+                instance.LOGGER.error("Exception in {} occured".format(func.__name__))
                 return 0
     return wrapped

--- a/djitellopy/tello.py
+++ b/djitellopy/tello.py
@@ -138,7 +138,7 @@ class Tello:
                     self.attitude = {'pitch': int(list[1]), 'roll': int(list[3]), 'yaw': int(list[5])}
             except Exception as e:
                 self.LOGGER.error(e)
-                self.LOGGER.error(f"Response was is {self.response_state}")
+                self.LOGGER.error("Response was is {}".format(self.response_state))
                 break
 
     def get_udp_video_address(self):
@@ -200,7 +200,7 @@ class Tello:
             return None
 
         if printinfo:
-            self.LOGGER.info(f'Response {command}: {response}')
+            self.LOGGER.info('Response {}: {}'.format(command, response))
 
         self.response = None
 

--- a/example.py
+++ b/example.py
@@ -1,4 +1,4 @@
-from TelloSDKPy.djitellopy.tello import Tello
+from djitellopy import Tello
 import cv2
 import pygame
 import numpy as np


### PR DESCRIPTION
- the `f"foo {bar} xar"` syntax was newly introduced in python 3.6. Commit d2d9deb uses str.format instead to support older versions
- commit c852ae2 fixes the import in example.py (see issue #32)