### PR TITLE
Remove client socket bind code

### DIFF
--- a/djitellopy/tello.py
+++ b/djitellopy/tello.py
@@ -110,7 +110,6 @@ class Tello:
         if not threads_initialized:
             # Run Tello command responses UDP receiver on background
             client_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            client_socket.bind(('', Tello.CONTROL_UDP_PORT))
             response_receiver_thread = Thread(target=Tello.udp_response_receiver)
             response_receiver_thread.daemon = True
             response_receiver_thread.start()


### PR DESCRIPTION
About Issue(https://github.com/damiafuentes/DJITelloPy/issues/143).
Remove client socket bind to CONTROL_UDP_PORT.
I confirmed it's work with my Tello(non-edu).