### PR TITLE
Fix Reconnect Issue

### DIFF
--- a/djitellopy/tello.py
+++ b/djitellopy/tello.py
@@ -110,6 +110,7 @@ class Tello:
         if not threads_initialized:
             # Run Tello command responses UDP receiver on background
             client_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            client_socket.bind(("", Tello.CONTROL_UDP_PORT))
             response_receiver_thread = Thread(target=Tello.udp_response_receiver)
             response_receiver_thread.daemon = True
             response_receiver_thread.start()


### PR DESCRIPTION
Client socket is never bound to receiving port to receive drone replies; This causes DJITelloPy to not be able to reconnect after running a script once. By binding it, the drone is able to reconnect without issue.

This was adopted from my other branch, [LightDJITelloPy](https://github.com/Desperationis/LightDJITelloPy).