### PR TITLE
UDP port collision fix

### DIFF
--- a/djitellopy/tello.py
+++ b/djitellopy/tello.py
@@ -22,6 +22,7 @@ client_socket: socket.socket
 class TelloException(Exception):
     pass
 
+
 @enforce_types
 class Tello:
     """Python wrapper to interact with the Ryze Tello drone using the official Tello api.
@@ -543,8 +544,6 @@ class Tello:
 
             if not self.get_current_state():
                 raise TelloException('Did not receive a state packet from the Tello')
-
-        # self.change_vs_udp(self.vs_udp_port)
 
     def send_keepalive(self):
         """Send a keepalive packet to prevent the drone from landing after 15s


### PR DESCRIPTION
This PR adds functionality for changing the video feed UDP port from the default (11111) to one set by the user, allowing multiple drones to connect to the same computer and stream video simultaneously. Without this change multiple drones will send data to the same port, causing port collision and rendering all video streams useless.

This "bug" only comes up if the user connects multiple drones to the same WiFi network and connects to them individually using multiple Tello() objects instead of one Swarm() object. This was motivated by a capstone project at Northeastern University that requires fine-positioning multiple drones simultaneously.

To this aim, the function `change_vs_udp` allows the user to set an arbitrary video stream udp port. There is also, for convenience, an optional parameter to the Tello() class constructor to set the udp port there, although I can understand if that was not necessary for others. The attribute `self.vs_udp_port` is added and used in place of the class attribute `VS_UDP_PORT`.

This functionality could be extended to also change the command port from the default but this was not an issue we came across in our project to our knowledge.

Using these changes we were able to stream video from three drones simultaneously without port collision, using the latest 2.4.0 release.

However, I didn't realize until beginning the PR process that there are many unreleased changes on `master`, and haven't been able to test them yet, so this has only been demonstrated to work with the cv2-based code and not the more recent PyAV versions. I don't believe there should be any problems but won't be able to upgrade and test for some time due to end-of-semester time constraints. If any maintainers want me to follow up with further tests or changes please let me know and I will complete them as soon as possible.

Thank you!