### PR TITLE
Move lock above initialization of self.frame

### DIFF
--- a/djitellopy/tello.py
+++ b/djitellopy/tello.py
@@ -1032,9 +1032,9 @@ class BackgroundFrameRead:
 
     def __init__(self, tello, address, with_queue = False, maxsize = 32):
         self.address = address
+        self.lock = Lock()
         self.frame = np.zeros([300, 400, 3], dtype=np.uint8)
         self.frames = deque([], maxsize)
-        self.lock = Lock()
         self.with_queue = with_queue
 
         # Try grabbing frame with PyAV


### PR DESCRIPTION
A colleague of mine recently had an issue where the frame was being set with the setter, which requires a lock. Not really sure why it doesn't give issues on my pc though. However, this change solves it.