### PR TITLE
Fixed sequential typo in docs (in `djitellopy/swarm`)

### DIFF
--- a/djitellopy/swarm.py
+++ b/djitellopy/swarm.py
@@ -81,7 +81,7 @@ class TelloSwarm:
         current [Tello][tello] instance.
 
         ```python
-        swarm.parallel(lambda i, tello: tello.land())
+        swarm.sequential(lambda i, tello: tello.land())
         ```
         """
 


### PR DESCRIPTION
Changed
`swarm.parallel(lambda i, tello: tello.land())`
to
`swarm.sequential(lambda i, tello: tello.land())`

in sequential(func) documentations. 